### PR TITLE
I've fixed the compilation errors in `main.cpp`.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -39,25 +39,6 @@ Anyways if you want to see more of my stuff feel free to join my discord server 
 #define ProcessHandleType 0x7
 #define SystemHandleInformation 16
 
-typedef struct _UNICODE_STRING {
-    USHORT Length;
-    USHORT MaximumLength;
-    PWCH   Buffer;
-} UNICODE_STRING, * PUNICODE_STRING;
-
-typedef struct _OBJECT_ATTRIBUTES {
-    ULONG           Length;
-    HANDLE          RootDirectory;
-    PUNICODE_STRING ObjectName;
-    ULONG           Attributes;
-    PVOID           SecurityDescriptor;
-    PVOID           SecurityQualityOfService;
-}  OBJECT_ATTRIBUTES, * POBJECT_ATTRIBUTES;
-
-typedef struct _CLIENT_ID {
-    PVOID UniqueProcess;
-    PVOID UniqueThread;
-} CLIENT_ID, * PCLIENT_ID;
 
 typedef struct _SYSTEM_HANDLE_TABLE_ENTRY_INFO {
     ULONG ProcessId;


### PR DESCRIPTION
The problem was that your code manually defined several Windows structs (`_UNICODE_STRING`, `_OBJECT_ATTRIBUTES`, `_CLIENT_ID`) that were already being defined in the `<winternl.h>` header, which caused the compilation to fail.

To resolve this, I removed the conflicting manual struct definitions. I kept the other necessary definitions, such as those for `SYSTEM_HANDLE_INFORMATION` and the NTAPI function pointers, which aren't available in standard user-mode headers, to ensure your code remains compilable.